### PR TITLE
Adaptahop automatic detection properties

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ test_tutorial_build/tutorial_*
 dist/*
 tests/test_dbs/
 .DS_store
+.pytest_cache/

--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,8 @@ install_requires = [
     'zope.sqlalchemy',
     'hupper',
     'six',
-    'scipy >= 0.14.0'
+    'scipy >= 0.14.0',
+    'more_itertools >= 8.0.0',
     ]
 
 tests_require = [

--- a/tangos/input_handlers/__init__.py
+++ b/tangos/input_handlers/__init__.py
@@ -35,6 +35,8 @@ class HandlerBase(object):
     Subclasses provide implementations for different formats and situations.
     """
 
+    halo_stat_file_class_name = "HaloStatFile"
+
     def __init__(self, basename):
         self.basename = self.strip_slashes(basename)
         self.quicker = False # a flag to indicate that corners may be cut in the interest of efficiency
@@ -86,7 +88,7 @@ class HandlerBase(object):
         #ts = DummyTimeStep()
         #ts.redshift = self.get_timestep_properties(ts_extension)['redshift']
         from . import caterpillar
-        statfile = halo_stat_files.HaloStatFile(self._extension_to_filename(ts_extension))
+        statfile = getattr(halo_stat_files, self.halo_stat_file_class_name)(self._extension_to_filename(ts_extension))
         return statfile
 
 

--- a/tangos/input_handlers/finding.py
+++ b/tangos/input_handlers/finding.py
@@ -65,9 +65,10 @@ class PatternBasedFileDiscovery(object):
         logger.info("Enumerate timestep extensions base=%r patterns=%s", base, self.patterns)
         for e in extensions:
             if self._is_able_to_load(e):
+                logger.info("Could load %s with class %s", e, self)
                 yield e[len(base) + 1:]
             else:
-                logger.info("Could not load %s",e)
+                logger.info("Could not load %s with class %s", e, self)
 
     def _is_able_to_load(self, fname):
         """Determine whether a named file can be loaded

--- a/tangos/input_handlers/finding.py
+++ b/tangos/input_handlers/finding.py
@@ -65,7 +65,6 @@ class PatternBasedFileDiscovery(object):
         logger.info("Enumerate timestep extensions base=%r patterns=%s", base, self.patterns)
         for e in extensions:
             if self._is_able_to_load(e):
-                logger.info("Could load %s with class %s", e, self)
                 yield e[len(base) + 1:]
             else:
                 logger.info("Could not load %s with class %s", e, self)

--- a/tangos/input_handlers/pynbody.py
+++ b/tangos/input_handlers/pynbody.py
@@ -19,6 +19,7 @@ from ..log import logger
 from six.moves import range
 
 
+
 _loaded_halocats = {}
 
 class DummyTimeStep(object):

--- a/tangos/input_handlers/pynbody.py
+++ b/tangos/input_handlers/pynbody.py
@@ -313,66 +313,6 @@ class PynbodyInputHandler(finding.PatternBasedFileDiscovery, HandlerBase):
         return estimated_part_mass
 
 
-class RamsesHOPInputHandler(PynbodyInputHandler):
-    patterns = ["output_0????"]
-    auxiliary_file_patterns = ["grp*.tag"]
-
-    def match_objects(
-        self,
-        ts1,
-        ts2,
-        halo_min,
-        halo_max,
-        dm_only=False,
-        threshold=0.005,
-        object_typetag="halo",
-        output_handler_for_ts2=None,
-    ):
-
-        f1 = self.load_timestep(ts1).dm
-        h1 = self._construct_halo_cat(ts1, object_typetag)
-
-        if output_handler_for_ts2 is None:
-            f2 = self.load_timestep(ts2).dm
-            h2 = self._construct_halo_cat(ts2, object_typetag)
-        else:
-            f2 = output_handler_for_ts2.load_timestep(ts2).dm
-            h2 = output_handler_for_ts2._construct_halo_cat(ts2, object_typetag)
-
-        bridge = pynbody.bridge.OrderBridge(f1, f2, monotonic=False)
-
-        return bridge.fuzzy_match_catalog(
-            halo_min,
-            halo_max,
-            threshold=threshold,
-            only_family=pynbody.family.dm,
-            groups_1=h1,
-            groups_2=h2,
-        )
-
-
-def RamsesAdaptaHOPInputHandler(RamsesHOPInputHandler):
-    patterns = ["output_0????"]
-    auxiliary_file_patterns = ["tree_bricks???"]
-
-    def available_object_property_names_for_timestep(
-        self, ts_extension, object_typetag
-    ):
-        f = self._load_timestep(ts_extension)
-        h = self._construct_halo_cat(ts_extension, object_typetag)
-
-        halo_attributes = list(h._halo_attributes)
-        if h._read_contamination:
-            halo_attributes.extend(h._halo_attributes_contam)
-
-        attrs = chain.from_iterable(
-            tuple(always_iterable(attr)) for (attr, _len, _dtype) in halo_attributes
-        )
-
-        # We return all properties but the ids of the particles contained in the halo
-        return [attr for attr in attrs if attr != "members"]
-
-
 class GadgetSubfindInputHandler(PynbodyInputHandler):
     patterns = ["snapshot_???"]
     auxiliary_file_patterns =["groups_???"]
@@ -631,4 +571,4 @@ class ChangaUseIDLInputHandler(ChangaInputHandler):
     halo_stat_file_class_name = "AmigaIDLStatFile"
     auxiliary_file_patterns = ["*.amiga.grp"]
 
-from . import caterpillar, eagle
+from . import caterpillar, eagle, ramsesHOP

--- a/tangos/input_handlers/pynbody.py
+++ b/tangos/input_handlers/pynbody.py
@@ -368,9 +368,16 @@ def RamsesAdaptaHOPInputHandler(RamsesHOPInputHandler):
         if h._read_contamination:
             halo_attributes.extend(h._halo_attributes_contam)
 
-        return list(chain.from_iterable(
+        attrs = chain.from_iterable(
             tuple(always_iterable(attr)) for (attr, _len, _dtype) in halo_attributes
-        ))
+        )
+
+        # We return all properties but the ids of the particles contained in the halo
+        return [
+            attr
+            for attr in attrs
+            if attr != "members"
+        ]
 
 class GadgetSubfindInputHandler(PynbodyInputHandler):
     patterns = ["snapshot_???"]

--- a/tangos/input_handlers/pynbody.py
+++ b/tangos/input_handlers/pynbody.py
@@ -196,11 +196,10 @@ class PynbodyInputHandler(finding.PatternBasedFileDiscovery, HandlerBase):
         return h  # pynbody.halo.AmigaGrpCatalogue(f)
 
 
-
-
     def match_objects(self, ts1, ts2, halo_min, halo_max,
                       dm_only=False, threshold=0.005, object_typetag='halo',
-                      output_handler_for_ts2=None):
+                      output_handler_for_ts2=None,
+                      fuzzy_match_kwa={}):
         if dm_only:
             only_family='dm'
         else:
@@ -220,8 +219,15 @@ class PynbodyInputHandler(finding.PatternBasedFileDiscovery, HandlerBase):
         if halo_max is None:
             halo_max = max(len(h2), len(h1))
 
-        return f1.bridge(f2).fuzzy_match_catalog(halo_min, halo_max, threshold=threshold,
-                                                 only_family=only_family, groups_1=h1, groups_2=h2)
+        return f1.bridge(f2).fuzzy_match_catalog(
+            halo_min,
+            halo_max,
+            threshold=threshold,
+            only_family=only_family,
+            groups_1=h1,
+            groups_2=h2,
+            **fuzzy_match_kwa,
+        )
 
     def enumerate_objects(self, ts_extension, object_typetag="halo", min_halo_particles=config.min_halo_particles):
         if self._can_enumerate_objects_from_statfile(ts_extension, object_typetag):

--- a/tangos/input_handlers/pynbody.py
+++ b/tangos/input_handlers/pynbody.py
@@ -312,24 +312,22 @@ class PynbodyInputHandler(finding.PatternBasedFileDiscovery, HandlerBase):
         logger.warn(" -- it will certainly be wrong for e.g. zoom simulations")
         return estimated_part_mass
 
+
 class RamsesHOPInputHandler(PynbodyInputHandler):
     patterns = ["output_0????"]
+    auxiliary_file_patterns = ["grp*.tag"]
 
-    def _is_able_to_load(self, ts_extension):
-        filepath = self._extension_to_filename(ts_extension)
-        try:
-            f = pynbody.load(filepath)
-            if self.quicker:
-                logger.warn("Pynbody was able to load %r, but because 'quicker' flag is set we won't check whether it can also load the halo files", filepath)
-            else:
-                h = pynbody.halo.HOPCatalogue(f)
-            return True
-        except (IOError, RuntimeError):
-            return False
-
-    def match_objects(self, ts1, ts2, halo_min, halo_max,
-                      dm_only=False, threshold=0.005, object_typetag='halo',
-                      output_handler_for_ts2=None):
+    def match_objects(
+        self,
+        ts1,
+        ts2,
+        halo_min,
+        halo_max,
+        dm_only=False,
+        threshold=0.005,
+        object_typetag="halo",
+        output_handler_for_ts2=None,
+    ):
 
         f1 = self.load_timestep(ts1).dm
         h1 = self._construct_halo_cat(ts1, object_typetag)
@@ -341,26 +339,25 @@ class RamsesHOPInputHandler(PynbodyInputHandler):
             f2 = output_handler_for_ts2.load_timestep(ts2).dm
             h2 = output_handler_for_ts2._construct_halo_cat(ts2, object_typetag)
 
-        bridge = pynbody.bridge.OrderBridge(f1,f2, monotonic=False)
+        bridge = pynbody.bridge.OrderBridge(f1, f2, monotonic=False)
 
-        return bridge.fuzzy_match_catalog(halo_min, halo_max, threshold=threshold,
-                                          only_family=pynbody.family.dm, groups_1=h1, groups_2=h2)
+        return bridge.fuzzy_match_catalog(
+            halo_min,
+            halo_max,
+            threshold=threshold,
+            only_family=pynbody.family.dm,
+            groups_1=h1,
+            groups_2=h2,
+        )
 
 
 def RamsesAdaptaHOPInputHandler(RamsesHOPInputHandler):
-    def _is_able_to_load(self, ts_extension):
-        filepath = self._extension_to_filename(ts_extension)
-        try:
-            f = pynbody.load(filepath)
-            if self.quicker:
-                logger.warn("Pynbody was able to load %r, but because 'quicker' flag is set we won't check whether it can also load the halo files", filepath)
-            else:
-                h = f.halos()
-            return isinstance(h, pynbody.halo.adaptahop.BaseAdaptaHOPCatalogue)
-        except (IOError, RuntimeError):
-            return False
+    patterns = ["output_0????"]
+    auxiliary_file_patterns = ["tree_bricks???"]
 
-    def available_object_property_names_for_timestep(self, ts_extension, object_typetag):
+    def available_object_property_names_for_timestep(
+        self, ts_extension, object_typetag
+    ):
         f = self._load_timestep(ts_extension)
         h = self._construct_halo_cat(ts_extension, object_typetag)
 
@@ -373,11 +370,8 @@ def RamsesAdaptaHOPInputHandler(RamsesHOPInputHandler):
         )
 
         # We return all properties but the ids of the particles contained in the halo
-        return [
-            attr
-            for attr in attrs
-            if attr != "members"
-        ]
+        return [attr for attr in attrs if attr != "members"]
+
 
 class GadgetSubfindInputHandler(PynbodyInputHandler):
     patterns = ["snapshot_???"]

--- a/tangos/input_handlers/pynbody.py
+++ b/tangos/input_handlers/pynbody.py
@@ -219,7 +219,7 @@ class PynbodyInputHandler(finding.PatternBasedFileDiscovery, HandlerBase):
         if halo_max is None:
             halo_max = max(len(h2), len(h1))
 
-        return f1.bridge(f2).fuzzy_match_catalog(
+        return self.create_bridge(f1, f2).fuzzy_match_catalog(
             halo_min,
             halo_max,
             threshold=threshold,
@@ -228,6 +228,10 @@ class PynbodyInputHandler(finding.PatternBasedFileDiscovery, HandlerBase):
             groups_2=h2,
             **fuzzy_match_kwa,
         )
+
+    @classmethod
+    def create_bridge(f1, f2):
+        return f1.bridge(f2)
 
     def enumerate_objects(self, ts_extension, object_typetag="halo", min_halo_particles=config.min_halo_particles):
         if self._can_enumerate_objects_from_statfile(ts_extension, object_typetag):
@@ -257,7 +261,7 @@ class PynbodyInputHandler(finding.PatternBasedFileDiscovery, HandlerBase):
             for i in range(istart, len(h)+istart):
                 try:
                     hi = h[i]
-                    if len(hi.dm)+len(hi.star)+len(hi.gas) > min_halo_particles:
+                    if len(hi.dm) + len(hi.star) + len(hi.gas) >= min_halo_particles:
                         yield i, i, len(hi.dm), len(hi.star), len(hi.gas)
                 except (ValueError, KeyError) as e:
                     pass

--- a/tangos/input_handlers/ramsesHOP.py
+++ b/tangos/input_handlers/ramsesHOP.py
@@ -50,6 +50,16 @@ class RamsesAdaptaHOPInputHandler(PynbodyInputHandler):
     patterns = ["output_0????"]
     auxiliary_file_patterns = ["tree_bricks???"]
 
+    _excluded_adaptahop_precalculated_properties = (
+        "members", "timestep", "level", "host_id", "first_subhalo_id", "next_subhalo_id",
+        "pos_x", "pos_y", "pos_z", "pos", "vel_x", "vel_y", "vel_z",
+        "angular_momentum_x", "angular_momentum_y", "angular_momentum_z",
+        "contaminated", "m_contam", "mtot_contam", "n_contam", "ntot_contam"
+    )
+    _included_adaptahop_additional_properties = (
+        "parent", "child", "shrink_center", "bulk_velocity", "contamination_fraction"
+    )
+
     def match_objects(self, ts1, ts2, halo_min, halo_max, dm_only=False, threshold=0.005,
                       object_typetag="halo", output_handler_for_ts2=None):
         import pynbody
@@ -82,14 +92,6 @@ class RamsesAdaptaHOPInputHandler(PynbodyInputHandler):
         except (IOError, RuntimeError):
             return False
 
-    def _exclude_adaptahop_precalculated_properties(self):
-        return ["members", "timestep", "level", "host_id", "first_subhalo_id", "next_subhalo_id",
-                "pos_x", "pos_y", "pos_z", "pos", "vel_x", "vel_y", "vel_z",
-                "angular_momentum_x", "angular_momentum_y", "angular_momentum_z",
-                "contaminated", "m_contam", "mtot_contam", "n_contam", "ntot_contam"]
-
-    def _include_additional_properties_derived_from_adaptahop(self):
-        return ["parent", "child", "shrink_center", "bulk_velocity", "contamination_fraction"]
 
     @staticmethod
     def _compute_contamination_fraction(adaptahop_halo):
@@ -111,9 +113,9 @@ class RamsesAdaptaHOPInputHandler(PynbodyInputHandler):
         attrs = chain.from_iterable(tuple(always_iterable(attr)) for (attr, _len, _dtype) in halo_attributes)
 
         # Import all precalculated properties except conflicting ones with Tangos syntax
-        property_list = [attr for attr in attrs if attr not in self._exclude_adaptahop_precalculated_properties()]
+        property_list = [attr for attr in attrs if attr not in self._excluded_adaptahop_precalculated_properties]
         # Add additional properties that can be derived from adaptahop
-        property_list += self._include_additional_properties_derived_from_adaptahop()
+        property_list += self._included_adaptahop_additional_properties
         return property_list
 
     @staticmethod
@@ -158,7 +160,7 @@ class RamsesAdaptaHOPInputHandler(PynbodyInputHandler):
 
             # Loop over all properties we wish to import
             for k in property_names:
-                if k in self._include_additional_properties_derived_from_adaptahop():
+                if k in self._included_adaptahop_additional_properties:
                     if k == "parent":
                         data = proxy_object.IncompleteProxyObjectFromFinderId(precalculated_properties['host_id'], 'halo')
                     if k == "child":

--- a/tangos/input_handlers/ramsesHOP.py
+++ b/tangos/input_handlers/ramsesHOP.py
@@ -17,6 +17,13 @@ class RamsesHOPInputHandler(PynbodyInputHandler):
 
     def match_objects(self, ts1, ts2, halo_min, halo_max, dm_only=True, threshold=0.005,
                       object_typetag="halo", output_handler_for_ts2=None):
+        import pynbody
+        if not dm_only:
+            logger.warn(
+                "`match_objects` was called with dm_only=%s, but AdaptaHOP only supports DM-only"
+                " catalogues at the moment. Falling back to DM-only.", dm_only
+            )
+            dm_only = True
         return super().match_objects(
             ts1,
             ts2,
@@ -25,7 +32,8 @@ class RamsesHOPInputHandler(PynbodyInputHandler):
             dm_only=dm_only,
             threshold=threshold,
             object_typetag=object_typetag,
-            output_handler_for_ts2=output_handler_for_ts2
+            output_handler_for_ts2=output_handler_for_ts2,
+            fuzzy_match_kwa={"use_family": pynbody.family.dm}
         )
 
     def _is_able_to_load(self, ts_extension):
@@ -59,8 +67,24 @@ class RamsesAdaptaHOPInputHandler(PynbodyInputHandler):
         "parent", "child", "shrink_center", "bulk_velocity", "contamination_fraction"
     )
 
+    def create_bridge(self, f1, f2):
+        import pynbody
+        # Ensure that f1.dm and f2.dm are not garbage-collected
+        self._f1dm = f1.dm
+        self._f2dm = f2.dm
+
+        return pynbody.bridge.OrderBridge(self._f1dm, self._f2dm, monotonic=False)
+
     def match_objects(self, ts1, ts2, halo_min, halo_max, dm_only=True, threshold=0.005,
                       object_typetag="halo", output_handler_for_ts2=None):
+        import pynbody
+        if not dm_only:
+            logger.warn(
+                "`match_objects` was called with dm_only=%s, but AdaptaHOP only supports DM-only"
+                " catalogues at the moment. Falling back to DM-only.", dm_only
+            )
+            dm_only = True
+
         return super().match_objects(
             ts1,
             ts2,
@@ -70,7 +94,7 @@ class RamsesAdaptaHOPInputHandler(PynbodyInputHandler):
             threshold=threshold,
             object_typetag=object_typetag,
             output_handler_for_ts2=output_handler_for_ts2,
-            fuzzy_match_kwa={"only_family": "dm"}
+            fuzzy_match_kwa={"use_family": pynbody.family.dm}
         )
 
 

--- a/tangos/input_handlers/ramsesHOP.py
+++ b/tangos/input_handlers/ramsesHOP.py
@@ -46,7 +46,7 @@ class RamsesAdaptaHOPInputHandler(RamsesHOPInputHandler):
 
     @staticmethod
     def _reformat_center(adaptahop_halo):
-        return np.array([adaptahop_halo.properties['x'], adaptahop_halo.properties['y'], adaptahop_halo.properties['z']])
+        return np.array([adaptahop_halo.properties['pos_x'], adaptahop_halo.properties['pos_y'], adaptahop_halo.properties['pos_z']])
 
     @staticmethod
     def _compute_contamination_fraction(adaptahop_halo):
@@ -101,7 +101,6 @@ class RamsesAdaptaHOPInputHandler(RamsesHOPInputHandler):
         if "child" in property_names:
             # Construct the mapping between parent and subhalos
             map_child_parent = self._get_map_child_subhalos(ts_extension)
-            print(map_child_parent)
     
         for halo_i in range(1, len(h)+1):  # AdaptaHOP catalogues start at 1
 
@@ -112,6 +111,7 @@ class RamsesAdaptaHOPInputHandler(RamsesHOPInputHandler):
 
             adaptahop_halo = h[halo_i]
             precalculated_properties = h[halo_i].properties
+            adaptahop_halo.physical_units() # make sure all units are physical before storing to database
 
             # Loop over all properties we wish to import
             for k in property_names:

--- a/tangos/input_handlers/ramsesHOP.py
+++ b/tangos/input_handlers/ramsesHOP.py
@@ -139,6 +139,7 @@ class RamsesAdaptaHOPInputHandler(RamsesCatalogueMixin, PynbodyInputHandler):
         # For AdaptaHOP handler, we do not need to load the entire snaphshot to enumerate
         # properties in the halo catalogue. If pynbody supports this, ask it to do so.
         h._index_parent = False
+        h.physical_units()  # make sure all units are physical before storing to database
 
         if "child" in property_names:
             # Construct the mapping between parent and subhalos
@@ -152,8 +153,7 @@ class RamsesAdaptaHOPInputHandler(RamsesCatalogueMixin, PynbodyInputHandler):
             all_data = [halo_i, halo_i]
 
             adaptahop_halo = h[halo_i]
-            precalculated_properties = h[halo_i].properties
-            adaptahop_halo.physical_units() # make sure all units are physical before storing to database
+            precalculated_properties = adaptahop_halo.properties
 
             # Loop over all properties we wish to import
             for k in property_names:

--- a/tangos/input_handlers/ramsesHOP.py
+++ b/tangos/input_handlers/ramsesHOP.py
@@ -138,6 +138,6 @@ class RamsesAdaptaHOPInputHandler(RamsesHOPInputHandler):
                     data = None
 
                 all_data.append(data)
-            logger.warn("Done with Halo %i" % halo_i)
+            logger.info("Done with Halo %i" % halo_i)
             yield all_data
 

--- a/tangos/input_handlers/ramsesHOP.py
+++ b/tangos/input_handlers/ramsesHOP.py
@@ -50,7 +50,12 @@ class RamsesAdaptaHOPInputHandler(RamsesHOPInputHandler):
 
     @staticmethod
     def _compute_contamination_fraction(adaptahop_halo):
-        return float(adaptahop_halo.properties['ntot_contam'] / adaptahop_halo.properties['ntot'])
+        # Deal with the potential case that contamination fraction has not been computed through AdaptaHOP
+        try:
+            contamination_fraction = float(adaptahop_halo.properties['ntot_contam'] / adaptahop_halo.properties['ntot'])
+        except KeyError:
+            contamination_fraction = None
+        return contamination_fraction
 
     def available_object_property_names_for_timestep(self, ts_extension, object_typetag):
         h = self._construct_halo_cat(ts_extension, object_typetag)

--- a/tangos/input_handlers/ramsesHOP.py
+++ b/tangos/input_handlers/ramsesHOP.py
@@ -11,23 +11,22 @@ class RamsesHOPInputHandler(PynbodyInputHandler):
     patterns = ["output_0????"]
     auxiliary_file_patterns = ["grp*.tag"]
 
-    def match_objects(self, ts1, ts2, halo_min, halo_max, dm_only=False, threshold=0.005,
+    def load_timestep(self, ts_extension, mode=None):
+        timestep = super().load_timestep(ts_extension, mode=mode)
+        return timestep.dm
+
+    def match_objects(self, ts1, ts2, halo_min, halo_max, dm_only=True, threshold=0.005,
                       object_typetag="halo", output_handler_for_ts2=None):
-        import pynbody
-        f1 = self.load_timestep(ts1).dm
-        h1 = self._construct_halo_cat(ts1, object_typetag)
-
-        if output_handler_for_ts2 is None:
-            f2 = self.load_timestep(ts2).dm
-            h2 = self._construct_halo_cat(ts2, object_typetag)
-        else:
-            f2 = output_handler_for_ts2.load_timestep(ts2).dm
-            h2 = output_handler_for_ts2._construct_halo_cat(ts2, object_typetag)
-
-        bridge = pynbody.bridge.OrderBridge(f1, f2, monotonic=False)
-
-        return bridge.fuzzy_match_catalog(halo_min, halo_max, threshold=threshold, only_family=pynbody.family.dm,
-                                          groups_1=h1, groups_2=h2)
+        return super().match_objects(
+            ts1,
+            ts2,
+            halo_min,
+            halo_max,
+            dm_only=dm_only,
+            threshold=threshold,
+            object_typetag=object_typetag,
+            output_handler_for_ts2=output_handler_for_ts2
+        )
 
     def _is_able_to_load(self, ts_extension):
         import pynbody
@@ -60,23 +59,20 @@ class RamsesAdaptaHOPInputHandler(PynbodyInputHandler):
         "parent", "child", "shrink_center", "bulk_velocity", "contamination_fraction"
     )
 
-    def match_objects(self, ts1, ts2, halo_min, halo_max, dm_only=False, threshold=0.005,
+    def match_objects(self, ts1, ts2, halo_min, halo_max, dm_only=True, threshold=0.005,
                       object_typetag="halo", output_handler_for_ts2=None):
-        import pynbody
-        f1 = self.load_timestep(ts1).dm
-        h1 = self._construct_halo_cat(ts1, object_typetag)
+        return super().match_objects(
+            ts1,
+            ts2,
+            halo_min,
+            halo_max,
+            dm_only=dm_only,
+            threshold=threshold,
+            object_typetag=object_typetag,
+            output_handler_for_ts2=output_handler_for_ts2,
+            fuzzy_match_kwa={"only_family": "dm"}
+        )
 
-        if output_handler_for_ts2 is None:
-            f2 = self.load_timestep(ts2).dm
-            h2 = self._construct_halo_cat(ts2, object_typetag)
-        else:
-            f2 = output_handler_for_ts2.load_timestep(ts2).dm
-            h2 = output_handler_for_ts2._construct_halo_cat(ts2, object_typetag)
-
-        bridge = pynbody.bridge.OrderBridge(f1, f2, monotonic=False)
-
-        return bridge.fuzzy_match_catalog(halo_min, halo_max, threshold=threshold, only_family=pynbody.family.dm,
-                                          groups_1=h1, groups_2=h2)
 
     def _is_able_to_load(self, ts_extension):
         import pynbody
@@ -86,7 +82,7 @@ class RamsesAdaptaHOPInputHandler(PynbodyInputHandler):
             if self.quicker:
                 logger.warn("Pynbody was able to load %r, but because 'quicker' flag is set we won't check whether it can also load the halo files", filepath)
             else:
-                h = f.halos(index_parent=False)
+                h = f.halos()
                 return isinstance(h, pynbody.halo.adaptahop.BaseAdaptaHOPCatalogue)
             return True
         except (IOError, RuntimeError):
@@ -201,7 +197,7 @@ class RamsesAdaptaHOPInputHandler(PynbodyInputHandler):
             for X in self._enumerate_objects_from_statfile(ts_extension, object_typetag):
                 yield X
         else:
-            logger.warn("No halo statistics file found for timestep %r",ts_extension)
+            logger.warn("No halo statistics file found for timestep %r", ts_extension)
 
             try:
                 h = self._construct_halo_cat(ts_extension, object_typetag)
@@ -216,7 +212,6 @@ class RamsesAdaptaHOPInputHandler(PynbodyInputHandler):
             for i in range(istart, len(h)+istart):
                 try:
                     hi = h[i]
-                    hi.properties
                     if hi.properties["npart"] > min_halo_particles:
                         yield i, i, hi.properties["npart"], 0, 0
                 except (ValueError, KeyError) as e:

--- a/tangos/input_handlers/ramsesHOP.py
+++ b/tangos/input_handlers/ramsesHOP.py
@@ -165,18 +165,26 @@ class RamsesAdaptaHOPInputHandler(PynbodyInputHandler):
                 if k in self._included_adaptahop_additional_properties:
                     if k == "parent":
                         data = proxy_object.IncompleteProxyObjectFromFinderId(precalculated_properties['host_id'], 'halo')
-                    if k == "child":
+                    elif k == "child":
                         # Determine whether halo has childs and create halo objects to it
                         try:
                             list_of_child = map_child_parent[halo_i]
                             data = [proxy_object.IncompleteProxyObjectFromFinderId(data_i, 'halo') for data_i in list_of_child]
                         except KeyError:
                             data = None
-
-                    # Avoid naming confusions with already defined PynbodyProperties
-                    if k == "shrink_center": data = (adaptahop_halo.properties['pos']).view(np.ndarray)
-                    if k == "bulk_velocity": data = (adaptahop_halo.properties['vel']).view(np.ndarray)
-                    if k == "contamination_fraction": data = self._compute_contamination_fraction(adaptahop_halo)
+                    elif k == "shrink_center":
+                        # Avoid naming confusions with already defined PynbodyProperties
+                        data = (adaptahop_halo.properties['pos']).view(np.ndarray)
+                    elif k == "bulk_velocity":
+                        data = (adaptahop_halo.properties['vel']).view(np.ndarray)
+                    elif k == "contamination_fraction":
+                        data = self._compute_contamination_fraction(adaptahop_halo)
+                    else:
+                        raise NotImplementedError(
+                            "Cannot handle property %s for halo catalogue %r" % (
+                                k, self
+                            )
+                        )
                 elif k in precalculated_properties:
                     data = precalculated_properties[k]
                     # Strip the unit as Tangos expects it to be a raw number

--- a/tangos/input_handlers/ramsesHOP.py
+++ b/tangos/input_handlers/ramsesHOP.py
@@ -54,6 +54,7 @@ class RamsesAdaptaHOPInputHandler(RamsesHOPInputHandler):
         try:
             contamination_fraction = float(adaptahop_halo.properties['ntot_contam'] / adaptahop_halo.properties['ntot'])
         except KeyError:
+            logger.warn("Ignoring import of contamination fraction which has not been stored on disk by AdaptaHOP")
             contamination_fraction = None
         return contamination_fraction
 

--- a/tangos/input_handlers/ramsesHOP.py
+++ b/tangos/input_handlers/ramsesHOP.py
@@ -1,0 +1,76 @@
+from .pynbody import PynbodyInputHandler
+
+class RamsesHOPInputHandler(PynbodyInputHandler):
+    """ Handling Ramses outputs with HOP halo finding (Eisenstein and Hut 1998)"""
+    patterns = ["output_0????"]
+    auxiliary_file_patterns = ["grp*.tag"]
+
+    def match_objects(self, ts1, ts2, halo_min, halo_max, dm_only=False, threshold=0.005,
+                      object_typetag="halo", output_handler_for_ts2=None):
+
+        f1 = self.load_timestep(ts1).dm
+        h1 = self._construct_halo_cat(ts1, object_typetag)
+
+        if output_handler_for_ts2 is None:
+            f2 = self.load_timestep(ts2).dm
+            h2 = self._construct_halo_cat(ts2, object_typetag)
+        else:
+            f2 = output_handler_for_ts2.load_timestep(ts2).dm
+            h2 = output_handler_for_ts2._construct_halo_cat(ts2, object_typetag)
+
+        bridge = pynbody.bridge.OrderBridge(f1, f2, monotonic=False)
+
+        return bridge.fuzzy_match_catalog(halo_min, halo_max, threshold=threshold, only_family=pynbody.family.dm,
+                                          groups_1=h1, groups_2=h2)
+
+
+def RamsesAdaptaHOPInputHandler(RamsesHOPInputHandler):
+    """ Handling Ramses outputs with AdaptaHOP halo and subhalo finding """
+
+    patterns = ["output_0????"]
+    auxiliary_file_patterns = ["tree_bricks???"]
+
+    def available_object_property_names_for_timestep(self, ts_extension, object_typetag):
+        f = self._load_timestep(ts_extension)
+        h = self._construct_halo_cat(ts_extension, object_typetag)
+
+        halo_attributes = list(h._halo_attributes)
+        if h._read_contamination:
+            halo_attributes.extend(h._halo_attributes_contam)
+
+        attrs = chain.from_iterable(
+            tuple(always_iterable(attr)) for (attr, _len, _dtype) in halo_attributes)
+
+        # We return all properties but the ids of the particles contained in the halo
+        return [attr for attr in attrs if attr != "members"]
+
+
+    # def _construct_group_cat(self, ts_extension):
+    #     f = self.load_timestep(ts_extension)
+    #     h = _loaded_halocats.get(id(f)+1, lambda: None)()
+    #     if h is None:
+    #         h = f.halos()
+    #         assert isinstance(h, pynbody.halo.SubfindCatalogue)
+    #         _loaded_halocats[id(f)+1] = weakref.ref(h)
+    #         f._db_current_groupcat = h  # keep alive for lifetime of simulation
+    #     return h
+
+
+
+    # def _construct_halo_cat(self, ts_extension, object_typetag):
+    #     if object_typetag== 'halo':
+    #         return super(RamsesHOPInputHandler, self)._construct_halo_cat(ts_extension, object_typetag)
+    #     elif object_typetag== 'group':
+    #         return self._construct_group_cat(ts_extension)
+    #     else:
+    #         raise ValueError("Unknown halo type %r" % object_typetag)
+
+
+    # def available_object_property_names_for_timestep(self, ts_extension, object_typetag):
+    #     if object_typetag=='halo':
+    #         return ["CM","HalfMassRad","VMax","VMaxRad","mass","pos","spin","vel","veldisp","parent"]
+    #     elif object_typetag=='group':
+    #         return ["mass","mcrit_200","mmean_200","mtop_200","rcrit_200","rmean_200","rtop_200","child"]
+    #     else:
+    #         raise ValueError("Unknown object typetag %r"%object_typetag)
+

--- a/tangos/input_handlers/ramsesHOP.py
+++ b/tangos/input_handlers/ramsesHOP.py
@@ -47,8 +47,17 @@ class RamsesAdaptaHOPInputHandler(RamsesHOPInputHandler):
         return halo_children
 
     def available_object_property_names_for_timestep(self, ts_extension, object_typetag):
-        return ['m200', 'r200']
+        h = self._construct_halo_cat(ts_extension, object_typetag)
 
+        halo_attributes = list(h._halo_attributes)
+        if h._read_contamination:
+            halo_attributes.extend(h._halo_attributes_contam)
+
+        attrs = chain.from_iterable(tuple(always_iterable(attr)) for (attr, _len, _dtype) in halo_attributes)
+
+        # We return all properties but the ids of the particles contained in the halo
+        return [attr for attr in attrs if attr != "members"]
+    
     def iterate_object_properties_for_timestep(self, ts_extension, object_typetag, property_names):
         h = self._construct_halo_cat(ts_extension, object_typetag)
 
@@ -63,5 +72,4 @@ class RamsesAdaptaHOPInputHandler(RamsesHOPInputHandler):
                     data = float(data)
 
                 all_data.append(data)
-            print(all_data)
             yield all_data

--- a/tangos/input_handlers/ramsesHOP.py
+++ b/tangos/input_handlers/ramsesHOP.py
@@ -43,10 +43,6 @@ class RamsesAdaptaHOPInputHandler(RamsesHOPInputHandler):
     def _include_additional_properties_derived_from_adaptahop(self):
         return ["parent", "shrink_center", "bulk_velocity", "contamination_fraction"]
 
-    # @staticmethod
-    # def _name_map_center(adaptahop_halo):
-    #     return np.array([adaptahop_halo.properties['pos_x'], adaptahop_halo.properties['pos_y'], adaptahop_halo.properties['pos_z']])
-
     @staticmethod
     def _compute_contamination_fraction(adaptahop_halo):
         # Deal with the potential case that contamination fraction has not been computed through AdaptaHOP
@@ -128,8 +124,8 @@ class RamsesAdaptaHOPInputHandler(RamsesHOPInputHandler):
                             data = None
 
                     # Avoid naming confusions with already defined PynbodyProperties
-                    if k == "shrink_center": data = adaptahop_halo['pos']
-                    if k == "bulk_velocity": data = adaptahop_halo['vel']
+                    if k == "shrink_center": data = (adaptahop_halo.properties['pos']).view(np.ndarray)
+                    if k == "bulk_velocity": data = (adaptahop_halo.properties['vel']).view(np.ndarray)
                     if k == "contamination_fraction": data = self._compute_contamination_fraction(adaptahop_halo)
                 elif k in precalculated_properties:
                     data = precalculated_properties[k]

--- a/tangos/input_handlers/ramsesHOP.py
+++ b/tangos/input_handlers/ramsesHOP.py
@@ -63,7 +63,7 @@ class RamsesAdaptaHOPInputHandler(RamsesHOPInputHandler):
 
         # Import all precalculated properties except conflicting ones with Tangos syntax
         property_list = [attr for attr in attrs if attr not in self._exclude_adaptahop_precalculated_properties()]
-        # Add additional properties that are baisc to most Tangos databases derived
+        # Add additional properties that are basic to most Tangos databases derived
         property_list += self._include_additional_properties_derived_from_adaptahop()
         return property_list
 

--- a/tangos/input_handlers/ramsesHOP.py
+++ b/tangos/input_handlers/ramsesHOP.py
@@ -81,7 +81,8 @@ class RamsesAdaptaHOPInputHandler(RamsesHOPInputHandler):
         halo_children = {}
         for halo_i in range(1, len(h)+1):  # AdaptaHOP catalogues start at 1
             halo_props = h[halo_i].properties
-            if halo_props['next_subhalo_id'] != -1:
+           
+            if halo_props['host_id'] != halo_i: # If halo isn't its own host, it is a subhalo
                 parent = halo_props['host_id']
                 if parent not in halo_children:
                     halo_children[parent] = []
@@ -91,15 +92,17 @@ class RamsesAdaptaHOPInputHandler(RamsesHOPInputHandler):
     def iterate_object_properties_for_timestep(self, ts_extension, object_typetag, property_names):
         h = self._construct_halo_cat(ts_extension, object_typetag)
 
+        if "child" in property_names:
+            # Construct the mapping between parent and subhalos
+            map_child_parent = self._get_map_child_subhalos(ts_extension)
+            print(map_child_parent)
+    
         for halo_i in range(1, len(h)+1):  # AdaptaHOP catalogues start at 1
 
             # Tangos expects data to have a finder offset, and a finder id following the stat file logic
             # I think these are irrelevant for AdaptaHOP catalogues which are derived directly from pynbody
             # Putting the finder ID twice seems to produce consistent results
             all_data = [halo_i, halo_i]
-
-            # Construct the mapping between parent and subhalos
-            map_child_parent = self._get_map_child_subhalos(ts_extension)
 
             # Loop over all properties we wish to import
             for k in property_names:

--- a/tangos/input_handlers/ramsesHOP.py
+++ b/tangos/input_handlers/ramsesHOP.py
@@ -37,16 +37,15 @@ class RamsesAdaptaHOPInputHandler(RamsesHOPInputHandler):
 
     def _exclude_adaptahop_precalculated_properties(self):
         return ["members", "timestep", "level", "host_id", "first_subhalo_id", "next_subhalo_id",
-                "x", "y", "z", "vx", "vy", "vz", "lx", "ly", "lz",
+                "pos_x", "pos_y", "pos_z", "pos", "vx", "vy", "vz", "lx", "ly", "lz",
                 "contaminated", "m_contam", "mtot_contam", "n_contam", "ntot_contam"]
 
     def _include_additional_properties_derived_from_adaptahop(self):
-        # I don't know what actually are vx, vy, vz and lx, ly, lz, but they could be added as reformatted 3D arrays here
-        return ["parent", "shrink_center", "contamination_fraction"]
+        return ["parent", "shrink_center", "bulk_velocity", "contamination_fraction"]
 
-    @staticmethod
-    def _reformat_center(adaptahop_halo):
-        return np.array([adaptahop_halo.properties['pos_x'], adaptahop_halo.properties['pos_y'], adaptahop_halo.properties['pos_z']])
+    # @staticmethod
+    # def _name_map_center(adaptahop_halo):
+    #     return np.array([adaptahop_halo.properties['pos_x'], adaptahop_halo.properties['pos_y'], adaptahop_halo.properties['pos_z']])
 
     @staticmethod
     def _compute_contamination_fraction(adaptahop_halo):
@@ -76,7 +75,6 @@ class RamsesAdaptaHOPInputHandler(RamsesHOPInputHandler):
     @staticmethod
     def _resolve_units(value):
         import pynbody
-        # TODO Solve the fact that AdapataHOP stores distances in Mpc, when Tangos physical units are kpc
         if (pynbody.units.is_unit(value)):
             return float(value)
         else:
@@ -129,7 +127,9 @@ class RamsesAdaptaHOPInputHandler(RamsesHOPInputHandler):
                         except KeyError:
                             data = None
 
-                    if k == "shrink_center": data = self._reformat_center(adaptahop_halo)
+                    # Avoid naming confusions with already defined PynbodyProperties
+                    if k == "shrink_center": data = adaptahop_halo['pos']
+                    if k == "bulk_velocity": data = adaptahop_halo['vel']
                     if k == "contamination_fraction": data = self._compute_contamination_fraction(adaptahop_halo)
                 elif k in precalculated_properties:
                     data = precalculated_properties[k]

--- a/tangos/input_handlers/ramsesHOP.py
+++ b/tangos/input_handlers/ramsesHOP.py
@@ -37,7 +37,7 @@ class RamsesCatalogueMixin:
             fuzzy_match_kwa={"use_family": pynbody.family.dm}
         )
 
-class RamsesHOPInputHandler(PynbodyInputHandler, RamsesCatalogueMixin):
+class RamsesHOPInputHandler(RamsesCatalogueMixin, PynbodyInputHandler):
     """ Handling Ramses outputs with HOP halo finding (Eisenstein and Hut 1998)"""
     patterns = ["output_0????"]
     auxiliary_file_patterns = ["grp*.tag"]
@@ -57,7 +57,7 @@ class RamsesHOPInputHandler(PynbodyInputHandler, RamsesCatalogueMixin):
 
 
 
-class RamsesAdaptaHOPInputHandler(PynbodyInputHandler, RamsesCatalogueMixin):
+class RamsesAdaptaHOPInputHandler(RamsesCatalogueMixin, PynbodyInputHandler):
     """ Handling Ramses outputs with AdaptaHOP halo and subhalo finding """
 
     patterns = ["output_0????"]

--- a/tangos/input_handlers/ramsesHOP.py
+++ b/tangos/input_handlers/ramsesHOP.py
@@ -42,7 +42,7 @@ class RamsesAdaptaHOPInputHandler(RamsesHOPInputHandler):
 
     def _include_additional_properties_derived_from_adaptahop(self):
         # I don't know what actually are vx, vy, vz and lx, ly, lz, but they could be added as reformatted 3D arrays here
-        return ["parent", "child", "shrink_center", "contamination_fraction"]
+        return ["parent", "shrink_center", "contamination_fraction"]
 
     @staticmethod
     def _reformat_center(adaptahop_halo):
@@ -104,11 +104,11 @@ class RamsesAdaptaHOPInputHandler(RamsesHOPInputHandler):
             # Putting the finder ID twice seems to produce consistent results
             all_data = [halo_i, halo_i]
 
+            adaptahop_halo = h[halo_i]
+            precalculated_properties = h[halo_i].properties
+
             # Loop over all properties we wish to import
             for k in property_names:
-
-                adaptahop_halo = h[halo_i]
-                precalculated_properties = h[halo_i].properties
 
                 if k in self._include_additional_properties_derived_from_adaptahop():
                     if k == "parent":

--- a/tangos/input_handlers/ramsesHOP.py
+++ b/tangos/input_handlers/ramsesHOP.py
@@ -158,16 +158,13 @@ class RamsesAdaptaHOPInputHandler(PynbodyInputHandler):
 
             # Loop over all properties we wish to import
             for k in property_names:
-
                 if k in self._include_additional_properties_derived_from_adaptahop():
                     if k == "parent":
                         data = proxy_object.IncompleteProxyObjectFromFinderId(precalculated_properties['host_id'], 'halo')
                     if k == "child":
-                        data = self._get_map_child_subhalos(ts_extension)
-
                         # Determine whether halo has childs and create halo objects to it
                         try:
-                            list_of_child = data[halo_i]
+                            list_of_child = map_child_parent[halo_i]
                             data = [proxy_object.IncompleteProxyObjectFromFinderId(data_i, 'halo') for data_i in list_of_child]
                         except KeyError:
                             data = None

--- a/tangos/input_handlers/ramsesHOP.py
+++ b/tangos/input_handlers/ramsesHOP.py
@@ -37,7 +37,8 @@ class RamsesAdaptaHOPInputHandler(RamsesHOPInputHandler):
 
     def _exclude_adaptahop_precalculated_properties(self):
         return ["members", "timestep", "level", "host_id", "first_subhalo_id", "next_subhalo_id",
-                "pos_x", "pos_y", "pos_z", "pos", "vx", "vy", "vz", "lx", "ly", "lz",
+                "pos_x", "pos_y", "pos_z", "pos", "vel_x", "vel_y", "vel_z",
+                "angular_momentum_x", "angular_momentum_y", "angular_momentum_z",
                 "contaminated", "m_contam", "mtot_contam", "n_contam", "ntot_contam"]
 
     def _include_additional_properties_derived_from_adaptahop(self):
@@ -64,7 +65,7 @@ class RamsesAdaptaHOPInputHandler(RamsesHOPInputHandler):
 
         # Import all precalculated properties except conflicting ones with Tangos syntax
         property_list = [attr for attr in attrs if attr not in self._exclude_adaptahop_precalculated_properties()]
-        # Add additional properties that are basic to most Tangos databases derived
+        # Add additional properties that can be derived from adaptahop
         property_list += self._include_additional_properties_derived_from_adaptahop()
         return property_list
 

--- a/tangos/input_handlers/ramsesHOP.py
+++ b/tangos/input_handlers/ramsesHOP.py
@@ -54,7 +54,7 @@ class RamsesAdaptaHOPInputHandler(PynbodyInputHandler):
         "members", "timestep", "level", "host_id", "first_subhalo_id", "next_subhalo_id",
         "pos_x", "pos_y", "pos_z", "pos", "vel_x", "vel_y", "vel_z",
         "angular_momentum_x", "angular_momentum_y", "angular_momentum_z",
-        "contaminated", "m_contam", "mtot_contam", "n_contam", "ntot_contam"
+        "contaminated", "m_contam", "mtot_contam", "n_contam", "ntot_contam",
     )
     _included_adaptahop_additional_properties = (
         "parent", "child", "shrink_center", "bulk_velocity", "contamination_fraction"
@@ -139,9 +139,11 @@ class RamsesAdaptaHOPInputHandler(PynbodyInputHandler):
                 halo_children[parent].append(halo_i)
         return halo_children
 
-    def iterate_object_properties_for_timestep(self, ts_extension, object_typetag, property_names, index_parent=True):
+    def iterate_object_properties_for_timestep(self, ts_extension, object_typetag, property_names):
         h = self._construct_halo_cat(ts_extension, object_typetag)
-        h._index_parent = index_parent
+        # For AdaptaHOP handler, we do not need to load the entire snaphshot to enumerate
+        # properties in the halo catalogue. If pynbody supports this, ask it to do so.
+        h._index_parent = False
 
         if "child" in property_names:
             # Construct the mapping between parent and subhalos

--- a/tangos/input_handlers/ramsesHOP.py
+++ b/tangos/input_handlers/ramsesHOP.py
@@ -6,24 +6,25 @@ import numpy as np
 from ..log import logger
 from .. import config
 
-class RamsesHOPInputHandler(PynbodyInputHandler):
-    """ Handling Ramses outputs with HOP halo finding (Eisenstein and Hut 1998)"""
-    patterns = ["output_0????"]
-    auxiliary_file_patterns = ["grp*.tag"]
+class RamsesCatalogueMixin:
+    def create_bridge(self, f1, f2):
+        import pynbody
+        # Ensure that f1.dm and f2.dm are not garbage-collected
+        self._f1dm = f1.dm
+        self._f2dm = f2.dm
 
-    def load_timestep(self, ts_extension, mode=None):
-        timestep = super().load_timestep(ts_extension, mode=mode)
-        return timestep.dm
+        return pynbody.bridge.OrderBridge(self._f1dm, self._f2dm, monotonic=False)
 
     def match_objects(self, ts1, ts2, halo_min, halo_max, dm_only=True, threshold=0.005,
                       object_typetag="halo", output_handler_for_ts2=None):
         import pynbody
         if not dm_only:
             logger.warn(
-                "`match_objects` was called with dm_only=%s, but AdaptaHOP only supports DM-only"
-                " catalogues at the moment. Falling back to DM-only.", dm_only
+                "`match_objects` was called with dm_only=%s, but %s only supports DM-only"
+                " catalogues at the moment. Falling back to DM-only.", dm_only, self.__class__.__name__
             )
             dm_only = True
+
         return super().match_objects(
             ts1,
             ts2,
@@ -35,6 +36,11 @@ class RamsesHOPInputHandler(PynbodyInputHandler):
             output_handler_for_ts2=output_handler_for_ts2,
             fuzzy_match_kwa={"use_family": pynbody.family.dm}
         )
+
+class RamsesHOPInputHandler(PynbodyInputHandler, RamsesCatalogueMixin):
+    """ Handling Ramses outputs with HOP halo finding (Eisenstein and Hut 1998)"""
+    patterns = ["output_0????"]
+    auxiliary_file_patterns = ["grp*.tag"]
 
     def _is_able_to_load(self, ts_extension):
         import pynbody
@@ -51,7 +57,7 @@ class RamsesHOPInputHandler(PynbodyInputHandler):
 
 
 
-class RamsesAdaptaHOPInputHandler(PynbodyInputHandler):
+class RamsesAdaptaHOPInputHandler(PynbodyInputHandler, RamsesCatalogueMixin):
     """ Handling Ramses outputs with AdaptaHOP halo and subhalo finding """
 
     patterns = ["output_0????"]
@@ -66,37 +72,6 @@ class RamsesAdaptaHOPInputHandler(PynbodyInputHandler):
     _included_adaptahop_additional_properties = (
         "parent", "child", "shrink_center", "bulk_velocity", "contamination_fraction"
     )
-
-    def create_bridge(self, f1, f2):
-        import pynbody
-        # Ensure that f1.dm and f2.dm are not garbage-collected
-        self._f1dm = f1.dm
-        self._f2dm = f2.dm
-
-        return pynbody.bridge.OrderBridge(self._f1dm, self._f2dm, monotonic=False)
-
-    def match_objects(self, ts1, ts2, halo_min, halo_max, dm_only=True, threshold=0.005,
-                      object_typetag="halo", output_handler_for_ts2=None):
-        import pynbody
-        if not dm_only:
-            logger.warn(
-                "`match_objects` was called with dm_only=%s, but AdaptaHOP only supports DM-only"
-                " catalogues at the moment. Falling back to DM-only.", dm_only
-            )
-            dm_only = True
-
-        return super().match_objects(
-            ts1,
-            ts2,
-            halo_min,
-            halo_max,
-            dm_only=dm_only,
-            threshold=threshold,
-            object_typetag=object_typetag,
-            output_handler_for_ts2=output_handler_for_ts2,
-            fuzzy_match_kwa={"use_family": pynbody.family.dm}
-        )
-
 
     def _is_able_to_load(self, ts_extension):
         import pynbody

--- a/tangos/input_handlers/ramsesHOP.py
+++ b/tangos/input_handlers/ramsesHOP.py
@@ -24,7 +24,7 @@ class RamsesHOPInputHandler(PynbodyInputHandler):
                                           groups_1=h1, groups_2=h2)
 
 
-def RamsesAdaptaHOPInputHandler(RamsesHOPInputHandler):
+class RamsesAdaptaHOPInputHandler(RamsesHOPInputHandler):
     """ Handling Ramses outputs with AdaptaHOP halo and subhalo finding """
 
     patterns = ["output_0????"]

--- a/tangos/input_handlers/ramsesHOP.py
+++ b/tangos/input_handlers/ramsesHOP.py
@@ -3,6 +3,8 @@ from ..util import proxy_object
 from itertools import chain
 from .pynbody import PynbodyInputHandler
 import numpy as np
+from ..log import logger
+
 
 class RamsesHOPInputHandler(PynbodyInputHandler):
     """ Handling Ramses outputs with HOP halo finding (Eisenstein and Hut 1998)"""
@@ -42,7 +44,7 @@ class RamsesAdaptaHOPInputHandler(RamsesHOPInputHandler):
                 "contaminated", "m_contam", "mtot_contam", "n_contam", "ntot_contam"]
 
     def _include_additional_properties_derived_from_adaptahop(self):
-        return ["parent", "shrink_center", "bulk_velocity", "contamination_fraction"]
+        return ["parent", "child", "shrink_center", "bulk_velocity", "contamination_fraction"]
 
     @staticmethod
     def _compute_contamination_fraction(adaptahop_halo):
@@ -136,5 +138,6 @@ class RamsesAdaptaHOPInputHandler(RamsesHOPInputHandler):
                     data = None
 
                 all_data.append(data)
+            logger.warn("Done with Halo %i" % halo_i)
             yield all_data
 

--- a/tangos/tools/property_importer.py
+++ b/tangos/tools/property_importer.py
@@ -1,6 +1,8 @@
 from __future__ import absolute_import
 from __future__ import print_function
 
+from ..input_handlers.ramsesHOP import RamsesAdaptaHOPInputHandler
+
 from .. import parallel_tasks
 from ..log import logger
 from .. import core
@@ -92,7 +94,12 @@ class PropertyImporter(GenericTangosTool):
         property_db_names = [core.dictionary.get_or_create_dictionary_item(self._session, name) for name in
                              property_names]
         rows_to_store = []
-        for values in self.handler.iterate_object_properties_for_timestep(ts.extension, object_typetag, property_names):
+        kwa = {}
+        # For AdaptaHOP handler, we do not need to load the entire snaphshot to enumerate
+        # properties in the halo catalogue
+        if isinstance(self.handler, RamsesAdaptaHOPInputHandler):
+            kwa["index_parent"] = False
+        for values in self.handler.iterate_object_properties_for_timestep(ts.extension, object_typetag, property_names, **kwa):
             db_object = self._object_cache.resolve_from_finder_offset(values[0], object_typetag)
             if db_object is not None:
                 for db_name, value in zip(property_db_names, values[2:]):

--- a/tangos/tools/property_importer.py
+++ b/tangos/tools/property_importer.py
@@ -94,12 +94,7 @@ class PropertyImporter(GenericTangosTool):
         property_db_names = [core.dictionary.get_or_create_dictionary_item(self._session, name) for name in
                              property_names]
         rows_to_store = []
-        kwa = {}
-        # For AdaptaHOP handler, we do not need to load the entire snaphshot to enumerate
-        # properties in the halo catalogue
-        if isinstance(self.handler, RamsesAdaptaHOPInputHandler):
-            kwa["index_parent"] = False
-        for values in self.handler.iterate_object_properties_for_timestep(ts.extension, object_typetag, property_names, **kwa):
+        for values in self.handler.iterate_object_properties_for_timestep(ts.extension, object_typetag, property_names):
             db_object = self._object_cache.resolve_from_finder_offset(values[0], object_typetag)
             if db_object is not None:
                 for db_name, value in zip(property_db_names, values[2:]):

--- a/tangos/tools/property_importer.py
+++ b/tangos/tools/property_importer.py
@@ -1,8 +1,6 @@
 from __future__ import absolute_import
 from __future__ import print_function
 
-from ..input_handlers.ramsesHOP import RamsesAdaptaHOPInputHandler
-
 from .. import parallel_tasks
 from ..log import logger
 from .. import core

--- a/tangos/tools/property_importer.py
+++ b/tangos/tools/property_importer.py
@@ -46,7 +46,8 @@ class PropertyImporter(GenericTangosTool):
             if np.issubdtype(value.dtype, np.number):
                 return core.halo_data.HaloProperty(object, name, value)
             else:
-                print(name, value)
+                logger.warn("Ignoring stat file entry key='%s' value='%s' as the value is not a number or an array of numbers",
+                        name.text, value)
         elif value is not None:
             logger.warn("Ignoring stat file entry key='%s' value='%s' as the value is not a number or an array of numbers",
                         name.text, value)

--- a/tangos/tools/property_importer.py
+++ b/tangos/tools/property_importer.py
@@ -39,12 +39,16 @@ class PropertyImporter(GenericTangosTool):
             value = value.relative_to_timestep_cache(self._object_cache).resolve(self._session)
             if value is not None:
                 return core.halo_data.HaloLink(object, value, name)
-        elif np.issubdtype(type(value), np.float) or np.issubdtype(type(value), np.integer):
+        elif isinstance(value, numbers.Number):
             return core.halo_data.HaloProperty(object, name, value)
+        elif isinstance(value, np.ndarray):
+            if np.issubdtype(value.dtype, np.number):
+                return core.halo_data.HaloProperty(object, name, value)
+            else:
+                print(name, value)
         elif value is not None:
-            logger.warn("Ignoring stat file entry key='%s' value='%s' as the value is not a number",
+            logger.warn("Ignoring stat file entry key='%s' value='%s' as the value is not a number or an array of numbers",
                         name.text, value)
-
         return None
 
     def _create_properties(self, name, object, values):

--- a/tangos/tools/property_importer.py
+++ b/tangos/tools/property_importer.py
@@ -8,6 +8,7 @@ from . import GenericTangosTool
 from ..util import proxy_object
 from ..util import timestep_object_cache
 import numpy as np
+import numbers
 
 class PropertyImporter(GenericTangosTool):
     tool_name = 'import-properties'

--- a/tangos/web/static/halo_view.js
+++ b/tangos/web/static/halo_view.js
@@ -151,7 +151,12 @@ function getPlotUriTwoVariables (name1, name2, typetag, extension) {
   var uri
   var plotformvals = $('#image_form').values()
   var plotType = plotformvals.type
-  if (plotType === 'gather') { uri = $('#timestep_url').text() + name1 + '/vs/' + name2 + '.' + extension } else if (plotType === 'cascade') {
+  if (plotType === 'gather') {
+    uri = $('#timestep_url').text()
+    if (uri.substr(uri.length - 1)!="/")
+      uri += "/";
+    uri += name1 + '/vs/' + name2 + '.' + extension
+  } else if (plotType === 'cascade') {
     uri = $('#cascade_url').text() +
             name1 + '/vs/' + name2 + '.' + extension
   }
@@ -244,6 +249,7 @@ function updateDownloadLink (url, extension) {
 }
 
 function loadImage (url, extension) {
+  console.log("loadImage",url);
   existingImgSrc = url
   if (extension === 'pdf') {
     objImg = $('<object type="application/pdf" data="' + url + '" height="100%" width="100%">')

--- a/tangos/web/views/halo_view.py
+++ b/tangos/web/views/halo_view.py
@@ -6,6 +6,7 @@ import numpy as np
 from .halo_data import format_number, _relative_description
 import sqlalchemy, sqlalchemy.orm
 from six.moves import zip
+import urllib.parse
 from . import halo_from_request
 
 class TimestepInfo(object):
@@ -129,4 +130,4 @@ def halo_view(request):
                                             halonumber=request.matchdict['halonumber']),
             'timestep_url': request.route_url('timestep_view',simid=request.matchdict['simid'],
                                             timestepid=request.matchdict['timestepid']),
-            'cascade_url': "/%s/%s/%s/"%(sim.escaped_basename,ts.escaped_extension,halo.basename)}
+            'cascade_url': urllib.parse.quote("/%s/%s/%s/"%(sim.escaped_basename,ts.escaped_extension,halo.basename))}


### PR DESCRIPTION
Hi @cphyc,

I am opening this PR to your forked main to open a discussion space before we submit to the Tangos public main.

I believe the edits I have made provide a base to import all AdaptaHOP properties, including links between sub halo and parent halos to be able to loop and browse them efficiently within the Tangos interface.

There are some open points to polish though

1. Tangos currently doesn't allow importing arrays, which is how the `shrink_center` should really be formatted rather than the `x, y, z` native to AdaptaHOP. This is something that I think should be fixed for Tangos in general but I am waiting for opinions on why this is (Issue https://github.com/pynbody/tangos/issues/156)
2. I currently eliminate a bunch of properties, either because I don't know what they correspond to, because they don't feel super useful to store, or because they are redundant with some native Tangos properties. What should and should not be included is an open discussion and I'm happy to edit the list.
3. We need to fix the units of these calculations-- AdaptaHOP properties lengths come out as `Mpc` whereas the entirety of Tangos assumes physical units in kpc. I am not sure whether such catalogue specific knowledge should be treated here or in pynbody.
4. There is some format specific logic (like reformatting arrays and computing contamination fraction) and it's unclear to me how much of this logic will be general to every AdaptaHOP catalogues, and how much is specific to the ones I am playing with. 

Otherwise, I have made some preliminary testing on the full scale PRACE runs, and the entirety of properties are imported for all halos in about ~1h, dominated by the writing of links to the database (i.e. I don't think it's possible to get this down, unless we get ride of the parent/subhalo feature or parallelise the loop on a halo by halo)

Let me know what you think,
Martin 